### PR TITLE
FOGL-2064 config fixes and readonly attribute added for plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.4.0)
 
 # Set the plugin name to build
-project(dht)
+project(dht11)
 
 # Supported options:
 # -DFOGLAMP_INCLUDE

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -24,7 +24,7 @@ using namespace std;
  * Default configuration
  */
 #define CONFIG  "{\"plugin\" : { \"description\" : \"DHT11 C south plugin\", " \
-                        "\"type\" : \"string\", \"default\" : \"foglamp-dht11\" }, " \
+                        "\"type\" : \"string\", \"default\" : \"dht11\", \"readonly\": \"true\" }, " \
                 "\"asset\" : { \"description\" : \"Asset name\", "\
                         "\"type\" : \"string\", \"default\" : \"dht11\" }, " \
                 "\"pin\" : { \"description\" : \"RPi pin to which DHT11 is attached\", " \


### PR DESCRIPTION
I have changed `dht to dht11`.

**Note:** As we have same plugin name(dht11) in python. Do we need to distinguish it?
 Does it like  pi_server way? (**pi_server**(in python) VS **PI_Server_V**2 (in C++))
