### PR TITLE
FOGL-2512 project name changed to dht11_V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ build
 
 # packaging
 packages/build
+
+# Editor
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.4.0)
 
 # Set the plugin name to build
-project(dht11)
+project(dht11_V2)
 
 # Supported options:
 # -DFOGLAMP_INCLUDE

--- a/make_deb
+++ b/make_deb
@@ -23,7 +23,7 @@ set -e
 
 plugin_type="south"
 plugin_name="dht"
-plugin_install_dirname="dht"
+plugin_install_dirname="dht11_V2"
 usage="$(basename "$0") [help|clean|cleanall]
 This script is used to create the Debian package of FoglAMP C++ '${plugin_name}' ${plugin_type} plugin
 Arguments:

--- a/packages/Debian/armhf/DEBIAN/postint
+++ b/packages/Debian/armhf/DEBIAN/postint
@@ -28,7 +28,7 @@
 set -e
 
 set_files_ownership () {
-    chown -R root:root /usr/local/foglamp/plugins/south/dht
+    chown -R root:root /usr/local/foglamp/plugins/south/dht11_V2
 }
 
 set_files_ownership

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -20,12 +20,13 @@
 #include <version.h>
 
 using namespace std;
+#define PLUGIN_NAME "dht11_V2"
 
 /**
  * Default configuration
  */
 #define CONFIG  "{\"plugin\" : { \"description\" : \"DHT11 C south plugin\", " \
-                        "\"type\" : \"string\", \"default\" : \"dht11\", \"readonly\": \"true\" }, " \
+                        "\"type\" : \"string\", \"default\" : \"" PLUGIN_NAME "\", \"readonly\": \"true\" }, " \
                 "\"asset\" : { \"description\" : \"Asset name\", "\
                         "\"type\" : \"string\", \"default\" : \"dht11\", \"order\": \"1\", " \
                         "\"displayName\": \"Asset Name\" }, " \
@@ -44,9 +45,9 @@ extern "C" {
  * The plugin information structure
  */
 static PLUGIN_INFORMATION info = {
-	"DHT11",                  // Name
+	PLUGIN_NAME,              // Name
 	VERSION,                  // Version
-	0,    			  // Flags
+	0,    			          // Flags
 	PLUGIN_TYPE_SOUTH,        // Type
 	"1.0.0",                  // Interface version
 	CONFIG                    // Default configuration
@@ -99,7 +100,7 @@ Reading plugin_poll(PLUGIN_HANDLE *handle)
 void plugin_reconfigure(PLUGIN_HANDLE *handle, string& newConfig)
 {
 ConfigCategory	conf("dht", newConfig);
-DHT11 		*dht11 = (DHT11*)*handle;
+DHT11 *dht11 = (DHT11*)*handle;
 
 	if (conf.itemExists("asset"))
                 dht11->setAssetName(conf.getValue("asset"));


### PR DESCRIPTION
- [x] make_deb okay
- [x] discovery okay
- [x] plugin working okay
- [x] debian installation okay
- [x] Both Python vs C versions are okay


**./make_deb**

```
pi@raspberrypi:~/foglamp-south-dht $ ./make_deb 
The package root directory is   : /home/pi/foglamp-south-dht
The FogLAMP required version    : >=1.5
The package will be built in    : /home/pi/foglamp-south-dht/packages/build
The architecture is set as      : armhf
The package name is             : foglamp-south-dht-1.5.0-armhf

Cloning into 'wiringPi'...
remote: Counting objects: 1177, done.
remote: Compressing objects: 100% (980/980), done.
remote: Total 1177 (delta 821), reused 212 (delta 142)
Receiving objects: 100% (1177/1177), 369.83 KiB | 349.00 KiB/s, done.
Resolving deltas: 100% (821/821), done.
wiringPi Build script
=====================


WiringPi Library
[UnInstall]
[Compile] wiringPi.c
[Compile] wiringSerial.c
[Compile] wiringShift.c
[Compile] piHiPri.c
[Compile] piThread.c
[Compile] wiringPiSPI.c
[Compile] wiringPiI2C.c
[Compile] softPwm.c
[Compile] softTone.c
[Compile] mcp23008.c
[Compile] mcp23016.c
wiringPi.c:1309:21: warning: ‘digitalWrite8Dummy’ defined but not used [-Wunused-function]
 static         void digitalWrite8Dummy       (UNU struct wiringPiNodeStruct *node, UNU int pin, UNU int value) { return ; }
                     ^~~~~~~~~~~~~~~~~~
wiringPi.c:1308:21: warning: ‘digitalRead8Dummy’ defined but not used [-Wunused-function]
 static unsigned int digitalRead8Dummy        (UNU struct wiringPiNodeStruct *node, UNU int UNU pin)            { return 0 ; }
                     ^~~~~~~~~~~~~~~~~
[Compile] mcp23017.c
[Compile] mcp23s08.c
[Compile] mcp23s17.c
[Compile] sr595.c
[Compile] pcf8574.c
[Compile] pcf8591.c
[Compile] mcp3002.c
[Compile] mcp3004.c
[Compile] mcp4802.c
[Compile] mcp3422.c
[Compile] max31855.c
[Compile] max5322.c
[Compile] ads1115.c
[Compile] sn3218.c
[Compile] bmp180.c
[Compile] htu21d.c
[Compile] ds18b20.c
[Compile] rht03.c
[Compile] drcSerial.c
[Compile] drcNet.c
[Compile] pseudoPins.c
[Compile] wpiExtensions.c
[Link (Dynamic)]
[Install Headers]
[Install Dynamic Lib]

WiringPi Devices Library
[UnInstall]
[Compile] ds1302.c
[Compile] maxdetect.c
[Compile] piNes.c
[Compile] gertboard.c
[Compile] piFace.c
[Compile] lcd128x64.c
[Compile] lcd.c
[Compile] scrollPhat.c
[Compile] piGlow.c
[Link (Dynamic)]
[Install Headers]
[Install Dynamic Lib]

GPIO Utility
[Compile] gpio.c
[Compile] readall.c
[Link]
[Install]

All Done.

NOTE: To compile programs with wiringPi, you need to add:
    -lwiringPi
  to your compile line(s) To use the Gertboard, MaxDetect, etc.
  code (the devLib), you need to also add:
    -lwiringPiDev
  to your compile line(s).

-- The C compiler identification is GNU 6.3.0
-- The CXX compiler identification is GNU 6.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- No options set.
   +Using found FOGLAMP_ROOT /home/pi/FogLAMP/
-- Using FOGLAMP_ROOT for includes
   +/home/pi/FogLAMP/C/common/include
   +/home/pi/FogLAMP/C/services/common/include
   +/home/pi/FogLAMP//C/thirdparty/rapidjson/include
-- Using FOGLAMP_ROOT for libs 
   +/home/pi/FogLAMP//cmake_build/C/lib
-- Configuring done
-- Generating done
-- Build files have been written to: /home/pi/foglamp-south-dht/build
[ 25%] Generating version header
Scanning dependencies of target dht11_V2
[ 50%] Building CXX object CMakeFiles/dht11_V2.dir/dht11.o
[ 75%] Building CXX object CMakeFiles/dht11_V2.dir/plugin.o
[100%] Linking CXX shared library libdht11_V2.so
[100%] Built target dht11_V2
Populating the package and updating version file...Done.
Building the new package...
dpkg-deb: building package 'foglamp-south-dht' in 'foglamp-south-dht-1.5.0-armhf.deb'.
Building Complete.

```

**Debian content**
```
pi@raspberrypi:~/foglamp-south-dht $ sudo dpkg -c /home/pi/foglamp-south-dht/packages/build/foglamp-south-dht-1.5.0-armhf.deb 
drwxr-xr-x pi/pi             0 2019-02-25 11:17 ./
drwxr-xr-x pi/pi             0 2019-02-25 11:17 ./usr/
drwxr-xr-x pi/pi             0 2019-02-25 11:17 ./usr/local/
drwxr-xr-x pi/pi             0 2019-02-25 11:17 ./usr/local/foglamp/
drwxr-xr-x pi/pi             0 2019-02-25 11:17 ./usr/local/foglamp/plugins/
drwxr-xr-x pi/pi             0 2019-02-25 11:17 ./usr/local/foglamp/plugins/south/
drwxr-xr-x pi/pi             0 2019-02-25 11:17 ./usr/local/foglamp/plugins/south/dht11_V2/
-rwxr-xr-x pi/pi         28888 2019-02-25 11:17 ./usr/local/foglamp/plugins/south/dht11_V2/libdht11_V2.so.1
lrwxrwxrwx pi/pi             0 2019-02-25 11:17 ./usr/local/foglamp/plugins/south/dht11_V2/libdht11_V2.so -> libdht11_V2.so.1
```
**Installation path**

```
/usr/local/foglamp/plugins/south/dht11_V2/libdht11_V2.so
```


[dht11.zip](https://github.com/foglamp/foglamp-south-dht/files/2900302/dht11.zip)


